### PR TITLE
https keep alive agent inplementation

### DIFF
--- a/src/core/SPRequest.ts
+++ b/src/core/SPRequest.ts
@@ -7,13 +7,24 @@ import * as _ from 'lodash';
 import * as util from 'util';
 import * as spauth from 'node-sp-auth';
 import * as crypto from 'crypto';
+import * as https from 'https';
 
 import { ISPRequest } from './ISPRequest';
 import { Cache } from './utils/Cache';
 
-export var requestDigestCache: Cache = new Cache();
+export let requestDigestCache: Cache = new Cache();
+
+const isUrlHttps: any = (url: string): boolean => {
+    return url.split('://')[0].toLowerCase() === 'https';
+};
 
 export function create(credentials: spauth.IAuthOptions, environment?: any): ISPRequest {
+
+  let agent: https.Agent = new https.Agent({
+    rejectUnauthorized: false,
+    keepAlive: true,
+    keepAliveMsecs: 10000
+  });
 
   /* backward compatibility with 1.1.5 */
   if (environment) {
@@ -35,7 +46,8 @@ export function create(credentials: spauth.IAuthOptions, environment?: any): ISP
 
       _.defaults(options, {
         json: true,
-        strictSSL: false
+        strictSSL: false,
+        agent: isUrlHttps(options.url) ? agent : undefined
       });
 
       spauth.getAuth(options.url, credentials)


### PR DESCRIPTION
Hi Sergei,

Please review the following PR with some enhancements for performance with HTTPS environments.
The PR adds HTTPS connection sharing feature which boosts responses.
It was revealed on the project with tons of requests in a queue by @airportyh in a [PR](https://github.com/koltyakov/sp-rest-proxy/pull/22) to sp-rest-proxy. Estimation of the SSL connection takes hundreds of milliseconds.
I've tested it with some other project and got positive results sometimes with drastic improvements per requests, especially for SPO which is much slower many of on-premise environments. 
In average, I got 15-17% improvements in SPO, which is a big deal, IMO.

Thank you in advanced!
